### PR TITLE
Add comment all scene components returned if no components specified

### DIFF
--- a/srv/GetPlanningScene.srv
+++ b/srv/GetPlanningScene.srv
@@ -1,4 +1,5 @@
 # Get parts of the planning scene that are of interest
+# All scene components are returned if none are specified
 PlanningSceneComponents components
 ---
 PlanningScene scene


### PR DESCRIPTION
Discussed in:
https://github.com/ros-planning/moveit/pull/1424

The get_planning_scene service should return the full scene if no specific component is specified. PR in main repository still pending.